### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -2,6 +2,7 @@
 	"meta6"       : "0",
 	"perl"        : "6.c",
 	"name"        : "Dice::Roller",
+	"license"     : "Artistic-2.0",
 	"version"     : "0.1.1",
 	"authors"     : [
 		"James Clark"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license